### PR TITLE
HIPP-1068: Add simple-api-deployment to the oas-discovery-proxy routes

### DIFF
--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,2 +1,3 @@
 # microservice specific routes
 -> /v1/oas-deployments uk.gov.hmrc.oasdiscoveryproxy.controllers.OasDiscoveryRouter
+-> /v1/simple-api-deployment uk.gov.hmrc.oasdiscoveryproxy.controllers.OasDiscoveryRouter


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/HIPP-1068